### PR TITLE
Fix Broken Edit Links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,8 @@
 site_name: KevBot's Wiki
 repo_url: "https://github.com/kmagameguy/wiki"
+repo_name: "kmagameguy/wiki"
+edit_uri: "edit/main/docs"
+
 theme: readthedocs
+
+copyright: 2021 &copy; Kmagameguy - Licensed under GPLv3


### PR DESCRIPTION
Seems like mkdocs is configured to look for `master` branch by default. This updates it so clicking the edit button on the site takes you to the `main` branch instead.