### PR TITLE
Describe How to Use Latest Stable Version of Apache2 on Raspbian OS

### DIFF
--- a/docs/raspbian_os/latest_apache2_on_raspbian.md
+++ b/docs/raspbian_os/latest_apache2_on_raspbian.md
@@ -1,0 +1,42 @@
+# Install Latest Apache2 On Raspbian
+
+As with most distributions, raspbian does not always come packaged
+with the latest copy of the apache2 webserver.  Since we are using
+apache to serve our nextcloud instance, we'll want to replace the
+built-in repo with the latest upstream built for Debian.  This ensures
+we always get critical security fixes on time.
+
+## How to Configure Raspbian
+
+Start by adding the upstream repository and its gpg keys to apt's source list.
+Make sure `wget` is available, then:
+
+```
+sudo wget -O /etc/apt/trusted.gpg.d/apache2.gpg https://packages.sury.org/apache2/apt.gpg
+echo "deb https://packages.sury.org/apache2/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/apache2.list
+sudo apt update
+```
+
+Then, install the latest apache:
+
+```
+sudo apt install -y apache2
+```
+
+To confirm whether the update worked, run:
+
+```
+apache2 -v
+```
+
+The commandline should print the now-installed apache2 version, which
+you can compare to the PPA's webpage.  The version on the system
+should match the latest version described in the PPA details:
+https://launchpad.net/~ondrej/+archive/ubuntu/apache2
+
+You can also restart the server manually if you'd like to make sure the
+updates are in use:
+
+```
+sudo service apache2 restart
+```


### PR DESCRIPTION
Like many other distros, Raspbian OS's package manager doesn't always offer the latest versions.  This is true of apache2, which always seems to be a few releases behind. This is a problem because it means users may not have all the latest security updates.  For example, just today [CVE-2021-41773](https://www.cve.org/CVERecord?id=CVE-2021-41773) details a path-traversal exploit on apache2 v2.4.49.

This PR adds a guide which describes how to pull in the latest stable release for use with Raspbian OS.  We can do this by pulling from the debian sources, rather than having to fiddle with compiling from source.